### PR TITLE
Fix for Issue #11 - Paged Response objects being used after having been closed.

### DIFF
--- a/quota-scan/pom.xml
+++ b/quota-scan/pom.xml
@@ -196,7 +196,7 @@
         <artifactId>function-maven-plugin</artifactId>
         <version>0.9.2</version>
         <configuration>
-          <functionTarget>functions.ScanProjectAllQuotas</functionTarget>
+          <functionTarget>functions.ScanProjectQuotas</functionTarget>
         </configuration>
       </plugin>
     </plugins>

--- a/quota-scan/src/main/java/functions/ScanProjectQuotas.java
+++ b/quota-scan/src/main/java/functions/ScanProjectQuotas.java
@@ -20,15 +20,16 @@ import static functions.ScanProjectQuotasHelper.loadBigQueryTable;
 
 import com.google.cloud.functions.BackgroundFunction;
 import com.google.cloud.functions.Context;
-import com.google.cloud.monitoring.v3.MetricServiceClient.ListTimeSeriesPagedResponse;
 import com.google.monitoring.v3.ProjectName;
 import functions.eventpojos.GCPProject;
 import functions.eventpojos.GCPResourceClient;
 import functions.eventpojos.PubSubMessage;
 import functions.eventpojos.TimeSeriesQuery;
+import functions.eventpojos.ProjectQuota;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -123,8 +124,8 @@ public class ScanProjectQuotas implements BackgroundFunction<PubSubMessage> {
       GCPProject gcpProject,
       Boolean isLimitData)
       throws IOException {
-    ListTimeSeriesPagedResponse projectQuotas = getQuota(gcpProject.getProjectName(), filter);
-    loadBigQueryTable(gcpResourceClient, projectQuotas, gcpProject.getProjectId(), isLimitData);
+    List<ProjectQuota> projectQuotas = getQuota(gcpProject, filter, isLimitData);
+    loadBigQueryTable(gcpResourceClient, projectQuotas);
     logger.log(
         Level.INFO, "Quotas loaded successfully for project Id:" + gcpProject.getProjectId());
   }

--- a/terraform/modules/qms/variables.tf
+++ b/terraform/modules/qms/variables.tf
@@ -85,13 +85,13 @@ variable "source_code_bucket_name" {
 variable "source_code_zip" {
   description = "Value of List and Scan Project Quotas source code zip file"
   type        = string
-  default     = "v4.2/quota-monitoring-solution-v4.2.zip"
+  default     = "v4.3/quota-monitoring-solution-v4.3.zip"
 }
 
 variable "source_code_notification_zip" {
   description = "Value of Notification Quota Alerts source code zip file"
   type        = string
-  default     = "v4.2/quota-monitoring-notification-v4.2.zip"
+  default     = "v4.3/quota-monitoring-notification-v4.3.zip"
 }
 
 variable "source_code_repo_url" {


### PR DESCRIPTION
This PR is a fix for Issue #11 

`getQuota` now iterates through the time series metrics and builds `ProjectQuota` objects for each metric.  Those are added to a list and then returned from `getQuota` so the `ListTimeSeriesPagedResponse` is only used in the local function.  The list of `ProjectQuota` objects is then handed off to the `loadBigQueryTable` function to be persisted into BigQuery.