### PR TITLE
Use list of emails and list of pubsub topics for alert policy notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,24 @@ gcloud iam service-accounts keys create key.json \
     vi terraform.tfvars
     ```
 
-![updated-tfvars](img/terraform-updated.png)
+    ```go
+    // Update values
+    project_id            = ""
+    region                = ""
+    service_account_email = ""
+    folders               = "[]"
+    organizations         = "[]"
+    alert_log_bucket_name = ""
+    notification_emails   = [ "" ]
+
+    // Optional to update
+    source_code_bucket_name       = "quota-monitoring-solution-source"
+    source_code_zip               = "v4.2/quota-monitoring-solution-v4.2.zip"
+    source_code_notification_zip  = "v4.2/quota-monitoring-notification-v4.2.zip"
+    scheduler_cron_job_frequency  = "0 0 * * *"
+    Alert_data_scanning_frequency = "every 12 hours"
+    threshold                     = "80"
+    ```
 
 ### 3.8 Run Terraform
 

--- a/terraform/modules/qms/README.md
+++ b/terraform/modules/qms/README.md
@@ -15,7 +15,7 @@ module "qms" {
   folders                       = "[678901]"
   organizations                 = "[123456]"
   alert_log_bucket_name         = "your-alert-log-bucket"
-  notification_email_address    = "alert@example.com"
+  notification_emails           = [ "alert@example.com", "oncall@example.com" ]
   threshold                     = "80"
 }
 ```
@@ -51,7 +51,8 @@ module "qms" {
 | <a name="input_cloud_function_scan_project_timeout"></a> [cloud\_function\_scan\_project\_timeout](#input\_cloud\_function\_scan\_project\_timeout) | Value of the timeout for the Cloud Function to scan Project quotas | `number` | `540` | no |
 | <a name="input_folders"></a> [folders](#input\_folders) | Value of the list of folders to be scanned for quota | `string` | n/a | yes |
 | <a name="input_log_sink_name"></a> [log\_sink\_name](#input\_log\_sink\_name) | Name for Log Sink | `string` | `"quota-monitoring-sink"` | no |
-| <a name="input_notification_email_address"></a> [notification\_email\_address](#input\_notification\_email\_address) | Email Address to receive email notifications | `string` | n/a | yes |
+| <a name="input_notification_emails"></a> [notification\_emails](#input\_notification\_emails) | Email Addresses to receive email notifications | `list(string)` | `[]` | no |
+| <a name="input_notification_pubsubs"></a> [notification\_pubsubs](#input\_notification\_pubsubs) | IDs of Pub/Sub topics to receive notifications | `list(string)` | `[]` | no |
 | <a name="input_organizations"></a> [organizations](#input\_organizations) | Value of the list of organization Ids to scanned for quota | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Value of the Project Id to deploy the solution | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Value of the region to deploy the solution. Use the same region as used for App Engine | `string` | n/a | yes |
@@ -76,6 +77,7 @@ module "qms" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_email0_id"></a> [email0\_id](#output\_email0\_id) | Full resource identifier for the notification channel. |
+| <a name="output_email_notif_channels"></a> [email\_notif\_channels](#output\_email\_notif\_channels) | List of full resource identifiers for email notification channels |
+| <a name="output_pubsub_notif_channels"></a> [pubsub\_notif\_channels](#output\_pubsub\_notif\_channels) | List of full resource identifiers for pubsub notification channels |
 
 <!-- END_TF_DOCS -->

--- a/terraform/modules/qms/outputs.tf
+++ b/terraform/modules/qms/outputs.tf
@@ -14,7 +14,12 @@ Copyright 2022 Google LLC
    limitations under the License.
 */
 
-output "email0_id" {
-  value = google_monitoring_notification_channel.email0.name
-  description = "Full resource identifier for the notification channel."
+output "email_notif_channels" {
+  value = [ for e in google_monitoring_notification_channel.emails  : e.name ]
+  description = "List of full resource identifiers for email notification channels"
+}
+
+output "pubsub_notif_channels" {
+  value = [ for p in google_monitoring_notification_channel.pubsubs : p.name ]
+  description = "List of full resource identifiers for pubsub notification channels"
 }

--- a/terraform/modules/qms/variables.tf
+++ b/terraform/modules/qms/variables.tf
@@ -259,9 +259,15 @@ variable "threshold" {
   type        = string
 }
 
-variable "notification_email_address" {
-  description = "Email Address to receive email notifications"
-  type        = string
+variable "notification_emails" {
+  description = "List of email addresses to receive email notifications"
+  type        = list(string)
+}
+
+variable "notification_pubsubs" {
+  description = "List of PubSub IDs to create notification chanels from, which will receive notifications"
+  type        = list(string)
+  default     = []
 }
 
 variable "alert_log_bucket_name" {


### PR DESCRIPTION
Rather than only allowing a single email address to receive notification emails, this allows users to define a list of emails and a list of Pub/Sub topic IDs to create notification channels from, and adds these channels to the alert policy's notification channel block.

The Pub/Sub topic channel was needed for configuring a Microsoft Teams webhook (Pub/Sub -> Cloud Function -> Teams Webhook). Other notification channel types (slack/webhooks/etc) can easily be added.

Updated READMEs.