### PR TITLE
Scale metrics to appropriate dimension

### DIFF
--- a/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
+++ b/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
@@ -172,9 +172,7 @@ public class ScanProjectQuotasHelper {
       MetricFix metricFix = new MetricFix();
       
       for (MetricFix dm: metricFixList) {    
-        logger.log(Level.INFO, "metric name : " + projectQuota.getMetric() + " ::::: " + dm.getMetric()); 
         if (projectQuota.getMetric().equals(dm.getMetric())) {
-          logger.log(Level.INFO, "Matched Name !!!! : " + projectQuota.getMetric() + " ::::: " + dm.getMetric()); 
           flag = true;
           metricFix = dm;
           break;
@@ -182,11 +180,9 @@ public class ScanProjectQuotasHelper {
       }
 
       if (flag) {
-        String metricValueStr = entry.getValue().toString(); 
-        logger.log(Level.INFO, "Actual Value : " + metricValueStr); 
+        String metricValueStr = entry.getValue().toString();  
         long metricValue = Long.parseLong(metricValueStr);
         metricValue = metricValue/metricFix.getFixer();
-        logger.log(Level.INFO, "Fixed Value : " + metricValue); 
         projectQuota.setMetricValue(Long.toString(metricValue));
       } else {
         projectQuota.setMetricValue(entry.getValue().toString());

--- a/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
+++ b/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
@@ -35,6 +35,7 @@ import functions.eventpojos.GCPProject;
 import functions.eventpojos.GCPResourceClient;
 import functions.eventpojos.ProjectQuota;
 import functions.eventpojos.TimeSeriesQuery;
+import functions.eventpojos.MetricFix;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -44,6 +45,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+const MetricFix[] metricFixList = new MetricFix[] {new MetricFix("storage.googleapis.com/google_egress_bandwidth", 60)};
 
 public class ScanProjectQuotasHelper {
   // Cloud Function Environment variable to identify usage and limit values
@@ -162,10 +165,31 @@ public class ScanProjectQuotasHelper {
     projectQuota.setTargetPoolName("NA");
     projectQuota.setRegion(ts.getResource().getLabelsMap().get("location"));
     projectQuota.setMetric(ts.getMetric().getLabelsMap().get("quota_metric"));
-    projectQuota.setMetricValue(entry.getValue().toString());
+
     if (isLimit) {
+      projectQuota.setMetricValue(entry.getValue().toString());
       projectQuota.setMetricValueType(METRIC_VALUE_LIMIT);
     } else {
+      String metricValueStr = entry.getValue().toString()
+      boolean flag = False
+      MetricFix metricFix;
+      
+      for (MetricFix dm: MetricFixList) {           
+        if projectQuota.getMetric() == dm.getMetric() {
+          flag = True
+          metricFix = dm
+          break;
+        } 
+      }
+
+      long metricValue = Long.parseLong(metricValueStr)
+      metricValue = metricValue/metricFix.fixer
+      if flag {
+        projectQuota.setMetricValue(metricValue.toString());
+      } else {
+        projectQuota.setMetricValue(entry.().toString());
+      }
+
       projectQuota.setMetricValueType(METRIC_VALUE_USAGE);
     }
     projectQuota.setVpcName("NA");

--- a/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
+++ b/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
@@ -166,15 +166,12 @@ public class ScanProjectQuotasHelper {
     projectQuota.setMetric(ts.getMetric().getLabelsMap().get("quota_metric"));
 
     if (isLimit) {
-      logger.log(Level.INFO, "LIMIT Timeseries Entry Value ::: " + ts.getMetric().getLabelsMap().get("quota_metric") + " ::: " + ts.getResource().getLabelsMap().get("location")  + " ::: "+ ts.getPointsList().get(0).getValue() + " ::: " + entry.getValue() + " ::: " + entry.getValue().toString());
       projectQuota.setMetricValue(entry.getValue().toString());
       projectQuota.setMetricValueType(METRIC_VALUE_LIMIT);
     } else {
       boolean flag = false;
       MetricFix metricFix = new MetricFix();
 
-      logger.log(Level.INFO, "ACTUAL Timeseries Entry Value ::: " + ts.getMetric().getLabelsMap().get("quota_metric") + " ::: " + ts.getResource().getLabelsMap().get("location") + " ::: " + ts.getPointsList().get(0).getValue() + " ::: " + entry.getValue() + " ::: " + entry.getValue().toString());
-      
       for (MetricFix dm: metricFixList) {    
         if (projectQuota.getMetric().equals(dm.getMetric())) {
           flag = true;

--- a/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
+++ b/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
@@ -152,6 +152,7 @@ public class ScanProjectQuotasHelper {
    * */
   private static ProjectQuota populateProjectQuota(
       TimeSeries ts, String projectId, Boolean isLimit) {
+    
     Map.Entry<FieldDescriptor, Object> entry =
         ts.getPointsList().get(0).getValue().getAllFields().entrySet().iterator().next();
     ProjectQuota projectQuota = new ProjectQuota();
@@ -165,11 +166,14 @@ public class ScanProjectQuotasHelper {
     projectQuota.setMetric(ts.getMetric().getLabelsMap().get("quota_metric"));
 
     if (isLimit) {
+      logger.log(Level.INFO, "LIMIT Timeseries Entry Value ::: " + ts.getMetric().getLabelsMap().get("quota_metric") + " ::: " + ts.getResource().getLabelsMap().get("location")  + " ::: "+ ts.getPointsList().get(0).getValue() + " ::: " + entry.getValue() + " ::: " + entry.getValue().toString());
       projectQuota.setMetricValue(entry.getValue().toString());
       projectQuota.setMetricValueType(METRIC_VALUE_LIMIT);
     } else {
       boolean flag = false;
       MetricFix metricFix = new MetricFix();
+
+      logger.log(Level.INFO, "ACTUAL Timeseries Entry Value ::: " + ts.getMetric().getLabelsMap().get("quota_metric") + " ::: " + ts.getResource().getLabelsMap().get("location") + " ::: " + ts.getPointsList().get(0).getValue() + " ::: " + entry.getValue() + " ::: " + entry.getValue().toString());
       
       for (MetricFix dm: metricFixList) {    
         if (projectQuota.getMetric().equals(dm.getMetric())) {

--- a/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
+++ b/quota-scan/src/main/java/functions/ScanProjectQuotasHelper.java
@@ -46,13 +46,11 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-const MetricFix[] metricFixList = new MetricFix[] {new MetricFix("storage.googleapis.com/google_egress_bandwidth", 60)};
-
 public class ScanProjectQuotasHelper {
   // Cloud Function Environment variable to identify usage and limit values
   public static final String METRIC_VALUE_USAGE = "usage";
   public static final String METRIC_VALUE_LIMIT = "limit";
-
+  public static final MetricFix[] metricFixList = new MetricFix[] {new MetricFix("storage.googleapis.com/google_egress_bandwidth", 60)};
   private static final Logger logger = Logger.getLogger(ScanProjectQuotasHelper.class.getName());
 
   /*
@@ -170,24 +168,28 @@ public class ScanProjectQuotasHelper {
       projectQuota.setMetricValue(entry.getValue().toString());
       projectQuota.setMetricValueType(METRIC_VALUE_LIMIT);
     } else {
-      String metricValueStr = entry.getValue().toString()
-      boolean flag = False
-      MetricFix metricFix;
+      boolean flag = false;
+      MetricFix metricFix = new MetricFix();
       
-      for (MetricFix dm: MetricFixList) {           
-        if projectQuota.getMetric() == dm.getMetric() {
-          flag = True
-          metricFix = dm
+      for (MetricFix dm: metricFixList) {    
+        logger.log(Level.INFO, "metric name : " + projectQuota.getMetric() + " ::::: " + dm.getMetric()); 
+        if (projectQuota.getMetric().equals(dm.getMetric())) {
+          logger.log(Level.INFO, "Matched Name !!!! : " + projectQuota.getMetric() + " ::::: " + dm.getMetric()); 
+          flag = true;
+          metricFix = dm;
           break;
         } 
       }
 
-      long metricValue = Long.parseLong(metricValueStr)
-      metricValue = metricValue/metricFix.fixer
-      if flag {
-        projectQuota.setMetricValue(metricValue.toString());
+      if (flag) {
+        String metricValueStr = entry.getValue().toString(); 
+        logger.log(Level.INFO, "Actual Value : " + metricValueStr); 
+        long metricValue = Long.parseLong(metricValueStr);
+        metricValue = metricValue/metricFix.getFixer();
+        logger.log(Level.INFO, "Fixed Value : " + metricValue); 
+        projectQuota.setMetricValue(Long.toString(metricValue));
       } else {
-        projectQuota.setMetricValue(entry.().toString());
+        projectQuota.setMetricValue(entry.getValue().toString());
       }
 
       projectQuota.setMetricValueType(METRIC_VALUE_USAGE);

--- a/quota-scan/src/main/java/functions/eventpojos/MetricFix.java
+++ b/quota-scan/src/main/java/functions/eventpojos/MetricFix.java
@@ -26,7 +26,7 @@ public class MetricFix {
   }
 
   public long getFixer() {
-    return fixer;
+    return this.fixer;
   }
 
   public void setFixer(long fixer) {
@@ -36,5 +36,8 @@ public class MetricFix {
   public MetricFix(String metric, long fixer){  
     this.metric = metric;  
     this.fixer = fixer;  
-    }  
+  }
+
+  public MetricFix(){
+  }
 }

--- a/quota-scan/src/main/java/functions/eventpojos/MetricFix.java
+++ b/quota-scan/src/main/java/functions/eventpojos/MetricFix.java
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 Google LLC
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package functions.eventpojos;
+
+public class MetricFix {
+  private String metric;
+  private Long fixer;
+
+  public String getMetric() {
+    return metric;
+  }
+
+  public void setMetric(String projectId) {
+    this.metric = metric;
+  }
+
+  public long getFixer() {
+    return fixer;
+  }
+
+  public void setFixer(long fixer) {
+    this.fixer = fixer;
+  }
+
+  public MetricFix(String metric, long fixer){  
+    this.metric = metric;  
+    this.fixer = fixer;  
+    }  
+}


### PR DESCRIPTION
For some metrics (Eg:- storage.googleapis.com/google_egress_bandwidth), the value retrieved has different dimension as compared to the dimension of limit. This needs to be fixed as it can result in incorrect alerts being sent.