### PR TITLE
fix: do not lint CHANGELOG.md

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -17,3 +17,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         LINTER_RULES_PATH: /
         MARKDOWN_CONFIG_FILE: .markdownlint.json
+        FILTER_REGEX_EXCLUDE: CHANGELOG.md


### PR DESCRIPTION
Adding exclusion rule for CHANGELOG.md so it isn't included in markdown linting.