### PR TITLE
Implemented #67 - use short-lived tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,9 @@ gcloud config set auth/impersonate_service_account \
 export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 ```
 
-*   **TIP**: If you get an error saying *unable to impersonate*, you will need to unset the 
-impersonation. Have the role added similar to below, then try again.
+*   **TIP**: If you get an error saying *unable to impersonate*, you will 
+need to unset the impersonation. Have the role added similar to below, then 
+try again.
 
     ```sh
     # unset impersonation

--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
     Note: In case terraform fails, run terraform plan and terraform apply again
 
 3.  Stop impersonating service account (when finished with terraform)
+
     ```sh
     gcloud config unset auth/impersonate_service_account
     ```

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 
 ### 3.7 Configure Terraform
 
-1.  Verify that you have these 4 files in your local directory:
+1.  Verify that you have these 3 files in your local directory:
     *   main.tf
     *   variables.tf
     *   terraform.tfvars
@@ -427,7 +427,7 @@ Note: In case terraform fails, run terraform plan and terraform apply again
     #### Console
 
     Click 'Run Now' on Cloud Job scheduler.
-    
+
     *Note: The status of the ‘Run Now’ button changes to ‘Running’ for a fraction
     of seconds.*
 

--- a/README.md
+++ b/README.md
@@ -371,10 +371,10 @@ Account created in the previous step at the Org A:
 
 ### 3.6 Set OAuth Token Using Service Account Impersonization
 
-Impersonate your host project service account and set environment variable 
-using temporary token to authenticate terraform. You will need to make 
-sure your user has the 
-[Service Account Token Creator role](https://cloud.google.com/iam/docs/service-account-permissions#token-creator-role) 
+Impersonate your host project service account and set environment variable
+using temporary token to authenticate terraform. You will need to make
+sure your user has the
+[Service Account Token Creator role](https://cloud.google.com/iam/docs/service-account-permissions#token-creator-role)
 to create short-lived credentials.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -371,7 +371,11 @@ Account created in the previous step at the Org A:
 
 ### 3.6 Set OAuth Token Using Service Account Impersonization
 
-Impersonate your host project service account and set environment variable using temporary token to authenticate terraform. You will need to make sure your user has the [Service Account Token Creator role](https://cloud.google.com/iam/docs/service-account-permissions#token-creator-role) to create short-lived credentials.
+Impersonate your host project service account and set environment variable 
+using temporary token to authenticate terraform. You will need to make 
+sure your user has the 
+[Service Account Token Creator role](https://cloud.google.com/iam/docs/service-account-permissions#token-creator-role) 
+to create short-lived credentials.
 
 ```sh
 gcloud config set auth/impersonate_service_account \
@@ -380,7 +384,7 @@ gcloud config set auth/impersonate_service_account \
 export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 ```
 
-- **TIP**: If you get an error saying *unable to impersonate*, you will need to unset the impersonation. Have the role added similar to below, then try again.
+*   **TIP**: If you get an error saying *unable to impersonate*, you will need to unset the impersonation. Have the role added similar to below, then try again.
 
     ```sh
     # unset impersonation
@@ -442,7 +446,7 @@ export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 
 1.  Initiate first job run in Cloud Scheduler.
 
-    #### Console
+    **Console**
 
     Click 'Run Now' on Cloud Job scheduler.
 
@@ -451,7 +455,7 @@ export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 
     ![run-cloud-scheduler](img/run_cloud_scheduler.png)
 
-    #### Terminal
+    **Terminal**
 
     ```sh
     gcloud scheduler jobs run quota-monitoring-cron-job --location <region>

--- a/README.md
+++ b/README.md
@@ -384,7 +384,8 @@ gcloud config set auth/impersonate_service_account \
 export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 ```
 
-*   **TIP**: If you get an error saying *unable to impersonate*, you will need to unset the impersonation. Have the role added similar to below, then try again.
+*   **TIP**: If you get an error saying *unable to impersonate*, you will need to unset the 
+impersonation. Have the role added similar to below, then try again.
 
     ```sh
     # unset impersonation

--- a/README.md
+++ b/README.md
@@ -380,6 +380,22 @@ gcloud config set auth/impersonate_service_account \
 export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 ```
 
+- **TIP**: If you get an error saying *unable to impersonate*, you will need to unset the impersonation. Have the role added similar to below, then try again.
+
+    ```sh
+    # unset impersonation
+    gcloud config unset auth/impersonate_service_account
+
+    # set your current authenticated user as var
+    PROJECT_USER=$(gcloud config get-value core/account)
+
+    # grant IAM role serviceAccountTokenCreator
+    gcloud iam service-accounts add-iam-policy-binding $SERVICE_ACCOUNT_ID@$DEFAULT_PROJECT_ID.iam.gserviceaccount.com \
+        --member user:$PROJECT_USER \
+        --role roles/iam.serviceAccountTokenCreator \
+        --condition=None
+    ```
+
 ### 3.7 Configure Terraform
 
 1.  Verify that you have these 3 files in your local directory:
@@ -415,10 +431,12 @@ export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
     *   Enable required APIs
     *   Create all resources and connect them.
 
-Note: In case terraform fails, run terraform plan and terraform apply again
+    Note: In case terraform fails, run terraform plan and terraform apply again
 
 3.  Stop impersonating service account (when finished with terraform)
-    *   `gcloud config unset auth/impersonate_service_account`
+    ```sh
+    gcloud config unset auth/impersonate_service_account
+    ```
 
 ### 3.9 Testing
 

--- a/README.md
+++ b/README.md
@@ -384,8 +384,8 @@ gcloud config set auth/impersonate_service_account \
 export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 ```
 
-*   **TIP**: If you get an error saying *unable to impersonate*, you will 
-need to unset the impersonation. Have the role added similar to below, then 
+*   **TIP**: If you get an error saying *unable to impersonate*, you will
+need to unset the impersonation. Have the role added similar to below, then
 try again.
 
     ```sh

--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -23,7 +23,6 @@ terraform {
 }
 
 provider "google" {
-  credentials = file("${var.creds_file}")
   project     = var.project_id
   region      = var.region
 }

--- a/terraform/example/variables.tf
+++ b/terraform/example/variables.tf
@@ -24,11 +24,6 @@ variable "region" {
   type        = string
 }
 
-variable "creds_file" {
-  type = string
-  default = "key.json"
-}
-
 variable "service_account_email" {
   description = "Value of the Service Account"
   type        = string


### PR DESCRIPTION
Fixed #67 

Removed less secure service account key implementation and replaced with short-lived tokens using service account impersonation for terraform authentication.

Added optional command line instructions for initiating initial test job with Cloud Scheduler.