### PR TITLE
fix: adding main.tf to the extra files for release-please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,6 +15,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE }}
           extra-files: |
             terraform/modules/qms/variables.tf
+            terraform/modules/qms/main.tf
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
         with:

--- a/terraform/modules/qms/main.tf
+++ b/terraform/modules/qms/main.tf
@@ -16,7 +16,7 @@ Copyright 2022 Google LLC
 
 terraform {
   provider_meta "google" {
-    module_name = "cloud-solutions/quota-monitoring-solution-deploy-v5.0" #x-release-please-version
+    module_name = "cloud-solutions/quota-monitoring-solution-deploy-v5.0" #x-release-please-minor
   }
 }
 


### PR DESCRIPTION
Adding `terraform/modules/qms/main.tf` to the list of extra files for release-please.  Also fixing the annotation for release-please so it only does version updates to the minor version.